### PR TITLE
Restore `format=text` param

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,10 +10,13 @@ async function handleRequest(request) {
     try {
         const quote = quotes[Math.floor(Math.random() * quotes.length)];
 
-        const json = JSON.stringify({ quote: quote });
+        const text = new URL(request.url).searchParams.get("format") === "text"
 
-        return new Response(json, {
-            headers: { ...headers, "content-type": "application/json" },
+        return new Response(text ? quote : JSON.stringify({ quote: quote }), {
+            headers: {
+                ...headers,
+                "content-type": text ? "text/plain" : "application/json"
+            },
         });
     } catch (error) {
         return new Response("An unexpected error ocurred", {


### PR DESCRIPTION
Hello @ajzbc, thank you for this endpoint.

I like to `git yolo` my commits, but last time I tried to use it I noticed the `format=text` param was ignored and returned the whole JSON.

These changes allow users to get the quote as plain text again.